### PR TITLE
Better Oculus Rift blob tracking

### DIFF
--- a/src/drv_oculus_rift/rift-sensor-blobwatch.h
+++ b/src/drv_oculus_rift/rift-sensor-blobwatch.h
@@ -23,7 +23,6 @@ struct blob {
 	uint16_t width;
 	uint16_t height;
 	uint32_t area;
-	uint32_t last_area;
 	uint32_t age;
 	int16_t track_index;
 	uint16_t pattern;

--- a/src/drv_oculus_rift/rift-sensor-blobwatch.h
+++ b/src/drv_oculus_rift/rift-sensor-blobwatch.h
@@ -29,7 +29,7 @@ struct blob {
 	uint16_t pattern;
 
 	uint32_t pattern_age;
-	int8_t pattern_bits[10];
+	uint16_t pattern_bits[10];
 	int8_t pattern_prev_phase;
 	int8_t led_id;
 };


### PR DESCRIPTION
This PR has 2 commits that 2 contribute to better blob tracking:

- Better flicker tracking by storing area directly rather than counting arbitrary 10% up/down edges.
- Better blob tracking by associating each blob to the closest blob from the previous frame.

Also, fix 2 out of bounds writes causing crashes in gst. And not allocating extends for every scan line when they are never used elsewhere.