### PR TITLE
wmr: Ignore unknown irq 23 transfers sent by Reverb G2

### DIFF
--- a/src/drv_wmr/wmr.c
+++ b/src/drv_wmr/wmr.c
@@ -121,7 +121,8 @@ static void update_device(ohmd_device* device)
 		// currently the only message type the hardware supports (I think)
 		if(buffer[0] == HOLOLENS_IRQ_SENSORS){
 			handle_tracker_sensor_msg(priv, buffer, size);
-		}else if(buffer[0] != HOLOLENS_IRQ_DEBUG){
+		}else if(buffer[0] != HOLOLENS_IRQ_DEBUG &&
+			 buffer[0] != HOLOLENS_IRQ_UNKNOWN_23){
 			LOGE("unknown message type: %u", buffer[0]);
 		}
 	}
@@ -209,7 +210,9 @@ static int config_command_sync(hid_device* hmd_imu, unsigned char type,
 			return -1;
 		if (buf[0] == HOLOLENS_IRQ_CONTROL)
 			return size;
-	} while (buf[0] == HOLOLENS_IRQ_SENSORS || buf[0] == HOLOLENS_IRQ_DEBUG);
+	} while (buf[0] == HOLOLENS_IRQ_SENSORS ||
+		 buf[0] == HOLOLENS_IRQ_DEBUG ||
+		 buf[0] == HOLOLENS_IRQ_UNKNOWN_23);
 
 	return -1;
 }

--- a/src/drv_wmr/wmr.h
+++ b/src/drv_wmr/wmr.h
@@ -20,6 +20,7 @@ typedef enum
 	HOLOLENS_IRQ_SENSORS = 1,
 	HOLOLENS_IRQ_CONTROL = 2,
 	HOLOLENS_IRQ_DEBUG = 3,
+	HOLOLENS_IRQ_UNKNOWN_23 = 23,
 } hololens_sensors_irq_cmd;
 
 typedef struct


### PR DESCRIPTION
That should improve configuration readout success rate.